### PR TITLE
Generalize graph-transformer functionality

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -25,7 +25,7 @@ def collate(batch):
     adj_s = [ b['adj_s'] for b in batch ]
     return {'image': image, 'label': label, 'id': id, 'adj_s': adj_s}
 
-def preparefeatureLabel(batch_graph, batch_label, batch_adjs):
+def preparefeatureLabel(batch_graph, batch_label, batch_adjs, n_features: int = 512):
     batch_size = len(batch_graph)
     labels = torch.LongTensor(batch_size)
     max_node_num = 0
@@ -36,7 +36,7 @@ def preparefeatureLabel(batch_graph, batch_label, batch_adjs):
     
     masks = torch.zeros(batch_size, max_node_num)
     adjs =  torch.zeros(batch_size, max_node_num, max_node_num)
-    batch_node_feat = torch.zeros(batch_size, max_node_num, 512)
+    batch_node_feat = torch.zeros(batch_size, max_node_num, n_features)
 
     for i in range(batch_size):
         cur_node_num =  batch_graph[i].shape[0]
@@ -72,8 +72,8 @@ class Trainer(object):
     def plot_cm(self):
         self.metrics.plotcm()
 
-    def train(self, sample, model):
-        node_feat, labels, adjs, masks = preparefeatureLabel(sample['image'], sample['label'], sample['adj_s'])
+    def train(self, sample, model, n_features: int = 512):
+        node_feat, labels, adjs, masks = preparefeatureLabel(sample['image'], sample['label'], sample['adj_s'], n_features=n_features)
         pred,labels,loss = model.forward(node_feat, labels, adjs, masks)
 
         return pred,labels,loss
@@ -93,8 +93,8 @@ class Evaluator(object):
     def plot_cm(self):
         self.metrics.plotcm()
 
-    def eval_test(self, sample, model, graphcam_flag=False):
-        node_feat, labels, adjs, masks = preparefeatureLabel(sample['image'], sample['label'], sample['adj_s'])
+    def eval_test(self, sample, model, graphcam_flag=False, n_features : int = 512):
+        node_feat, labels, adjs, masks = preparefeatureLabel(sample['image'], sample['label'], sample['adj_s'], n_features=n_features)
         if not graphcam_flag:
             with torch.no_grad():
                 pred,labels,loss = model.forward(node_feat, labels, adjs, masks)

--- a/main.py
+++ b/main.py
@@ -101,6 +101,8 @@ for epoch in range(num_epochs):
             #scheduler(optimizer, i_batch, epoch, best_pred)
             scheduler.step(epoch)
 
+            sample_batched = sample_batched.to(device)
+
             preds,labels,loss = trainer.train(sample_batched, model)
 
             optimizer.zero_grad()

--- a/main.py
+++ b/main.py
@@ -152,7 +152,7 @@ for epoch in range(num_epochs):
                 best_pred = val_acc
                 if not test:
                     print("saving model...")
-                    torch.save(model.state_dict(), model_path + task_name + ".pth")
+                    torch.save(model.state_dict(), os.path.join(model_path, task_name + ".pth"))
 
             log = ""
             log = log + 'epoch [{}/{}] ------ acc: train = {:.4f}, val = {:.4f}'.format(epoch+1, num_epochs, trainer.get_scores(), evaluator.get_scores()) + "\n"

--- a/main.py
+++ b/main.py
@@ -62,7 +62,7 @@ print("creating models......")
 num_epochs = args.num_epochs
 learning_rate = args.lr
 
-model = Classifier(n_class)
+model = Classifier(n_class, n_features=args.n_features)
 model = nn.DataParallel(model)
 if args.resume:
     print('load model{}'.format(args.resume))
@@ -104,7 +104,7 @@ for epoch in range(num_epochs):
             sample_batched['image'] = [image.to(device) for image in sample_batched['image']]
             sample_batched['adj_s'] = [adj_s.to(device) for adj_s in sample_batched['adj_s']]
 
-            preds,labels,loss = trainer.train(sample_batched, model)
+            preds,labels,loss = trainer.train(sample_batched, model, n_features=args.n_features)
 
             optimizer.zero_grad()
             loss.backward()
@@ -135,7 +135,7 @@ for epoch in range(num_epochs):
 
             for i_batch, sample_batched in enumerate(dataloader_val):
                 #pred, label, _ = evaluator.eval_test(sample_batched, model)
-                preds, labels, _ = evaluator.eval_test(sample_batched, model, graphcam)
+                preds, labels, _ = evaluator.eval_test(sample_batched, model, graphcam, n_features=args.n_features)
                 
                 total += len(labels)
 

--- a/main.py
+++ b/main.py
@@ -51,7 +51,7 @@ if train:
     total_train_num = len(dataloader_train) * batch_size
 
 ids_val = open(args.val_set).readlines()
-dataset_val = GraphDataset(os.path.join(data_path, ""), ids_val)
+dataset_val = GraphDataset(os.path.join(data_path, ""), ids_val, site=args.site)
 dataloader_val = torch.utils.data.DataLoader(dataset=dataset_val, batch_size=batch_size, num_workers=10, collate_fn=collate, shuffle=False, pin_memory=True)
 total_val_num = len(dataloader_val) * batch_size
     

--- a/main.py
+++ b/main.py
@@ -86,7 +86,7 @@ if not test:
 trainer = Trainer(n_class)
 evaluator = Evaluator(n_class)
 
-best_pred = 0.0
+best_pred = None
 for epoch in range(num_epochs):
     # optimizer.zero_grad()
     model.train()
@@ -94,7 +94,7 @@ for epoch in range(num_epochs):
     total = 0.
 
     current_lr = optimizer.param_groups[0]['lr']
-    print('\n=>Epoches %i, learning rate = %.7f, previous best = %.4f' % (epoch+1, current_lr, best_pred))
+    print('\n=>Epoches %i, learning rate = %.7f' % (epoch+1, current_lr) + (', previous best = %.4f' % best_pred if (best_pred is not None) else ''))
 
     if train:
         for i_batch, sample_batched in enumerate(dataloader_train):
@@ -148,7 +148,7 @@ for epoch in range(num_epochs):
             # torch.cuda.empty_cache()
 
             val_acc = evaluator.get_scores()
-            if val_acc > best_pred: 
+            if (best_pred is None) or (val_acc > best_pred): 
                 best_pred = val_acc
                 if not test:
                     print("saving model...")

--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ batch_size = args.batch_size
 
 if train:
     ids_train = open(args.train_set).readlines()
-    dataset_train = GraphDataset(os.path.join(data_path, ""), ids_train, args.site)
+    dataset_train = GraphDataset(os.path.join(data_path, ""), ids_train, site=args.site)
     dataloader_train = torch.utils.data.DataLoader(dataset=dataset_train, batch_size=batch_size, num_workers=10, collate_fn=collate, shuffle=True, pin_memory=True, drop_last=True)
     total_train_num = len(dataloader_train) * batch_size
 

--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ batch_size = args.batch_size
 
 if train:
     ids_train = open(args.train_set).readlines()
-    dataset_train = GraphDataset(os.path.join(data_path, ""), ids_train)
+    dataset_train = GraphDataset(os.path.join(data_path, ""), ids_train, args.site)
     dataloader_train = torch.utils.data.DataLoader(dataset=dataset_train, batch_size=batch_size, num_workers=10, collate_fn=collate, shuffle=True, pin_memory=True, drop_last=True)
     total_train_num = len(dataloader_train) * batch_size
 

--- a/main.py
+++ b/main.py
@@ -101,9 +101,6 @@ for epoch in range(num_epochs):
             #scheduler(optimizer, i_batch, epoch, best_pred)
             scheduler.step(epoch)
 
-            sample_batched['image'] = [image.to(device) for image in sample_batched['image']]
-            sample_batched['adj_s'] = [adj_s.to(device) for adj_s in sample_batched['adj_s']]
-
             preds,labels,loss = trainer.train(sample_batched, model, n_features=args.n_features)
 
             optimizer.zero_grad()

--- a/main.py
+++ b/main.py
@@ -101,8 +101,8 @@ for epoch in range(num_epochs):
             #scheduler(optimizer, i_batch, epoch, best_pred)
             scheduler.step(epoch)
 
-            sample_batched['image'] = sample_batched['image'].to(device)
-            sample_batched['adj_s'] = sample_batched['adj_s'].to(device)
+            sample_batched['image'] = [image.to(device) for image in sample_batched['image']]
+            sample_batched['adj_s'] = [adj_s.to(device) for adj_s in sample_batched['adj_s']]
 
             preds,labels,loss = trainer.train(sample_batched, model)
 

--- a/main.py
+++ b/main.py
@@ -101,7 +101,8 @@ for epoch in range(num_epochs):
             #scheduler(optimizer, i_batch, epoch, best_pred)
             scheduler.step(epoch)
 
-            sample_batched = sample_batched.to(device)
+            sample_batched['image'] = sample_batched['image'].to(device)
+            sample_batched['adj_s'] = sample_batched['adj_s'].to(device)
 
             preds,labels,loss = trainer.train(sample_batched, model)
 

--- a/models/GraphTransformer.py
+++ b/models/GraphTransformer.py
@@ -55,13 +55,14 @@ class Classifier(nn.Module):
         if graphcam_flag:
             s_matrix = torch.argmax(s[0], dim=1)
             from os import path
-            torch.save(s_matrix, 'graphcam/s_matrix.pt')
-            torch.save(s[0], 'graphcam/s_matrix_ori.pt')
+            os.makedirs('graphcam', exist_ok=True)
+            torch.save(s_matrix, path.join('graphcam', 's_matrix.pt'))
+            torch.save(s[0], path.join('graphcam', 's_matrix_ori.pt'))
             
-            if path.exists('graphcam/att_1.pt'):
-                os.remove('graphcam/att_1.pt')
-                os.remove('graphcam/att_2.pt')
-                os.remove('graphcam/att_3.pt')
+            if path.exists(path.join('graphcam', 'att_1.pt')):
+                os.remove(path.join('graphcam', 'att_1.pt'))
+                os.remove(path.join('graphcam', 'att_2.pt'))
+                os.remove(path.join('graphcam', 'att_3.pt'))
     
         X, adj, mc1, o1 = dense_mincut_pool(X, adj, s, mask)
         b, _, _ = X.shape
@@ -79,7 +80,7 @@ class Classifier(nn.Module):
         if graphcam_flag:
             print('GraphCAM enabled')
             p = F.softmax(out)
-            torch.save(p, 'graphcam/prob.pt')
+            torch.save(p, path.join('graphcam', 'prob.pt'))
             index = np.argmax(out.cpu().data.numpy(), axis=-1)
 
             for index_ in range(p.size(1)):
@@ -95,6 +96,6 @@ class Classifier(nn.Module):
                 cam = self.transformer.relprop(torch.tensor(one_hot_vector).to(X.device), method="transformer_attribution", is_ablation=False, 
                                             start_layer=0, **kwargs)
 
-                torch.save(cam, 'graphcam/cam_{}.pt'.format(index_))
+                torch.save(cam, path.join('graphcam', 'cam_{}.pt'.format(index_)))
 
         return pred,labels,loss

--- a/models/GraphTransformer.py
+++ b/models/GraphTransformer.py
@@ -16,7 +16,7 @@ from .gcn import GCNBlock
 from torch_geometric.nn import GCNConv, DenseGraphConv, dense_mincut_pool
 from torch.nn import Linear
 class Classifier(nn.Module):
-    def __init__(self, n_class):
+    def __init__(self, n_class, n_features: int = 512):
         super(Classifier, self).__init__()
 
         self.embed_dim = 64
@@ -30,7 +30,7 @@ class Classifier(nn.Module):
         self.bn = 1
         self.add_self = 1
         self.normalize_embedding = 1
-        self.conv1 = GCNBlock(512,self.embed_dim,self.bn,self.add_self,self.normalize_embedding,0.,0)       # 64->128
+        self.conv1 = GCNBlock(n_features,self.embed_dim,self.bn,self.add_self,self.normalize_embedding,0.,0)       # 64->128
         self.pool1 = Linear(self.embed_dim, self.node_cluster_num)                                          # 100-> 20
 
 

--- a/models/GraphTransformer.py
+++ b/models/GraphTransformer.py
@@ -82,7 +82,7 @@ class Classifier(nn.Module):
             torch.save(p, 'graphcam/prob.pt')
             index = np.argmax(out.cpu().data.numpy(), axis=-1)
 
-            for index_ in range(3):
+            for index_ in range(p.size(1)):
                 one_hot = np.zeros((1, out.size()[-1]), dtype=np.float32)
                 one_hot[0, index_] = out[0][index_]
                 one_hot_vector = one_hot

--- a/option.py
+++ b/option.py
@@ -13,6 +13,7 @@ class Options():
         parser = argparse.ArgumentParser(description='PyTorch Classification')
         # model and dataset 
         parser.add_argument('--n_class', type=int, default=4, help='classification classes')
+        parser.add_argument('--n_features', type=int, default=512, help='number of features per node in the graph')
         parser.add_argument('--data_path', type=str, help='path to dataset where images store')
         parser.add_argument('--train_set', type=str, help='train')
         parser.add_argument('--val_set', type=str, help='validation')

--- a/option.py
+++ b/option.py
@@ -25,6 +25,7 @@ class Options():
         parser.add_argument('--log_interval_local', type=int, default=10, help='classification classes')
         parser.add_argument('--resume', type=str, default="", help='path for model')
         parser.add_argument('--graphcam', action='store_true', default=False, help='GraphCAM')
+        parser.add_argument('--site', type=str, default="LUAD", help='site of the dataset, if using a canonical dataset')
 
         # the parser
         self.parser = parser
@@ -38,4 +39,8 @@ class Options():
 
         if args.test:
             args.num_epochs = 1
+
+        if args.site.strip().lower() == 'none':
+            args.site = None
+
         return args

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -144,6 +144,8 @@ class GraphDataset(data.Dataset):
             adj_s = torch.load(adj_s_path, map_location='cpu')
         else:
             raise FileNotFoundError(f'adj_s.pt for {graph_name} doesn\'t exist')
+        if adj_s.is_sparse:
+            adj_s = adj_s.to_dense()
 
         sample['image'] = features
         sample['adj_s'] = adj_s

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -136,16 +136,12 @@ class GraphDataset(data.Dataset):
         feature_path = os.path.join(graph_path, graph_name, 'features.pt')
         if os.path.exists(feature_path):
             features = torch.load(feature_path, map_location='cpu')
-            if torch.cuda.is_available():
-                features = features.to('cuda')
         else:
             raise FileNotFoundError(f'features.pt for {graph_name} doesn\'t exist')
 
         adj_s_path = os.path.join(graph_path, graph_name, 'adj_s.pt')
         if os.path.exists(adj_s_path):
             adj_s = torch.load(adj_s_path, map_location='cpu')
-            if torch.cuda.is_available():
-                adj_s = adj_s.to('cuda')
         else:
             raise FileNotFoundError(f'adj_s.pt for {graph_name} doesn\'t exist')
 


### PR DESCRIPTION
I made some edits to the graph-transformer to allow use on datasets other than LUAD. When running the shell scripts provided in tmi2022 or sticking to defaults, it should behave exactly as before; the changes I made simply allow for more flexibility when calling functions directly.

Changes include
* Allowing for datasets that have more or less than 512 node features or 3 label classes
* Allow ingestion of datasets that don't follow the same site pattern as the datasets that the Graph-Transformer was built for
   * Add a longer docstring explaining the requirements 
* Require that a model is always saved after the first epoch
* Allow for operating systems that don't use `/` in filenames (for the Graph-Transformer portions only)
* Allow for loading dataset tensors that were created on a CPU instead of a CUDA GPU